### PR TITLE
Auto-update dependencies

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,22 @@
+on:
+  schedule:
+    - cron: 0 0 * * *
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+name: Cron
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update packages
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          EXECUTE_COMMANDS: |
+            git submodule update --init
+            git -C yosys-src pull --ff origin master
+          COMMIT_MESSAGE: 'Update dependencies'
+          PR_BRANCH_PREFIX: 'update-deps/'
+          PR_BRANCH_NAME: '${PR_ID}'
+          PR_TITLE: 'Auto-update dependencies'
+          AUTO_MERGE_THRESHOLD_DAYS: 1


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/YoWASP/yosys/tree/develop)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>git submodule update --init</em></summary>

```Shell
Submodule path 'yosys-src': checked out '8c4cb1885b2cb6b7b26d7b9b7113e174c0eefffd'
```

### stderr:

```Shell
Submodule 'yosys-src' (https://github.com/YosysHQ/yosys) registered for path 'yosys-src'
Cloning into '/home/runner/work/yosys/yosys/yosys-src'...
```

</details>
<details>
<summary><em>git -C yosys-src pull --ff origin master</em></summary>

```Shell
Updating 8c4cb188..000fd081
Fast-forward
 CHANGELOG                                   |    2 +
 CODEOWNERS                                  |    1 +
 Makefile                                    |    5 +
 backends/cxxrtl/cxxrtl_backend.cc           |   31 +-
 backends/ilang/ilang_backend.cc             |    2 -
 frontends/aiger/aigerparse.cc               |   20 +-
 frontends/ast/ast.cc                        |    1 +
 frontends/ast/ast.h                         |    1 +
 frontends/ast/genrtlil.cc                   |   24 +
 frontends/ast/simplify.cc                   |   16 +-
 frontends/verific/verific.cc                |   64 +-
 frontends/verilog/verilog_lexer.l           |    8 +
 frontends/verilog/verilog_parser.y          |   82 +-
 kernel/celltypes.h                          |   40 +
 kernel/constids.inc                         |    3 +
 kernel/log.h                                |   25 +-
 kernel/macc.h                               |    2 -
 kernel/modtools.h                           |    6 +-
 kernel/rtlil.cc                             |  464 +++++-
 kernel/rtlil.h                              |   20 +
 kernel/yosys.h                              |    8 +
 manual/CHAPTER_CellLib.tex                  |  435 +++++-
 passes/cmds/stat.cc                         |    5 +-
 passes/opt/opt_expr.cc                      |   45 +-
 passes/opt/opt_merge.cc                     |    4 +-
 passes/opt/pmux2shiftx.cc                   |    6 +-
 passes/opt/wreduce.cc                       |   26 +-
 passes/pmgen/pmgen.py                       |   20 +-
 passes/sat/expose.cc                        |   30 +-
 passes/sat/fmcombine.cc                     |    3 +-
 passes/sat/qbfsat.cc                        |  420 ++---
 passes/sat/qbfsat.h                         |  252 +++
 passes/sat/sim.cc                           |    5 +-
 passes/techmap/Makefile.inc                 |    1 +
 passes/techmap/abc9.cc                      |    2 +-
 passes/techmap/abc9_ops.cc                  |    4 +-
 passes/techmap/clkbufmap.cc                 |    2 +-
 passes/techmap/dff2dffe.cc                  |   40 +-
 passes/techmap/dff2dffs.cc                  |   18 +-
 passes/techmap/dfflegalize.cc               | 1356 ++++++++++++++++
 passes/techmap/dfflibmap.cc                 |   10 +-
 passes/techmap/extractinv.cc                |    2 +-
 passes/techmap/simplemap.cc                 |  141 +-
 passes/techmap/techmap.cc                   |    5 +-
 passes/techmap/zinit.cc                     |   58 +-
 passes/tests/test_abcloop.cc                |    4 +-
 passes/tests/test_cell.cc                   |    8 +-
 techlibs/common/gen_fine_ffs.py             |  153 ++
 techlibs/common/simcells.v                  | 2218 +++++++++++++++++++++++++--
 techlibs/common/simlib.v                    |  156 ++
 techlibs/common/techmap.v                   |    2 +-
 techlibs/ecp5/Makefile.inc                  |    3 +-
 techlibs/ecp5/cells_map.v                   |  143 +-
 techlibs/ecp5/ecp5_ffinit.cc                |  197 ---
 techlibs/ecp5/synth_ecp5.cc                 |   11 +-
 techlibs/efinix/cells_map.v                 |   66 +-
 techlibs/efinix/synth_efinix.cc             |    2 +-
 techlibs/gowin/Makefile.inc                 |    1 -
 techlibs/gowin/cells_map.v                  |  185 +--
 techlibs/gowin/cells_sim.v                  |  359 ++++-
 techlibs/gowin/determine_init.cc            |   72 -
 techlibs/gowin/synth_gowin.cc               |   36 +-
 techlibs/ice40/Makefile.inc                 |    1 -
 techlibs/ice40/ff_map.v                     |   43 +-
 techlibs/ice40/ice40_ffinit.cc              |  179 ---
 techlibs/ice40/synth_ice40.cc               |    9 +-
 techlibs/intel/cyclone10lp/cells_map.v      |    2 +-
 techlibs/intel/cycloneiv/cells_map.v        |    2 +-
 techlibs/intel/cycloneive/cells_map.v       |    2 +-
 techlibs/intel/cyclonev/cells_map.v         |    2 +-
 techlibs/intel/max10/cells_map.v            |    2 +-
 techlibs/intel_alm/Makefile.inc             |   11 +-
 techlibs/intel_alm/common/abc9_map.v        |   18 +
 techlibs/intel_alm/common/abc9_model.v      |   10 +
 techlibs/intel_alm/common/abc9_unmap.v      |   11 +
 techlibs/intel_alm/common/bram_m10k.txt     |    4 +-
 techlibs/intel_alm/common/bram_m10k_map.v   |   31 -
 techlibs/intel_alm/common/dff_map.v         |  123 +-
 techlibs/intel_alm/common/dff_sim.v         |   41 +-
 techlibs/intel_alm/common/dsp_map.v         |   49 +
 techlibs/intel_alm/common/dsp_sim.v         |   35 +
 techlibs/intel_alm/common/megafunction_bb.v |   63 +
 techlibs/intel_alm/common/mem_sim.v         |   44 +
 techlibs/intel_alm/common/quartus_rename.v  |   68 +
 techlibs/intel_alm/synth_intel_alm.cc       |   93 +-
 techlibs/sf2/cells_map.v                    |   16 +-
 techlibs/xilinx/cells_map.v                 |   48 +-
 techlibs/xilinx/synth_xilinx.cc             |    4 +-
 techlibs/xilinx/xc6s_ff_map.v               |   24 +-
 techlibs/xilinx/xc7_ff_map.v                |   24 +-
 tests/arch/gowin/init-error.ys              |    5 +
 tests/arch/gowin/init.ys                    |   12 +-
 tests/arch/intel_alm/add_sub.ys             |   10 +
 tests/arch/intel_alm/adffs.ys               |   48 +
 tests/arch/intel_alm/blockram.ys            |    6 +
 tests/arch/intel_alm/counter.ys             |   14 +
 tests/arch/intel_alm/dffs.ys                |   22 +
 tests/arch/intel_alm/fsm.ys                 |   29 +-
 tests/arch/intel_alm/logic.ys               |   14 +
 tests/arch/intel_alm/lutram.ys              |   23 +-
 tests/arch/intel_alm/mul.ys                 |   23 +
 tests/arch/intel_alm/mux.ys                 |   46 +-
 tests/arch/intel_alm/quartus_ice.ys         |   14 +
 tests/arch/intel_alm/shifter.ys             |   11 +
 tests/arch/intel_alm/tribuf.ys              |   14 +
 tests/opt/bug2221.ys                        |   16 +
 tests/opt/opt_expr_combined_assign.ys       |   83 +
 tests/svtypes/static_cast_negative.ys       |    4 +
 tests/svtypes/static_cast_nonconst.ys       |    4 +
 tests/svtypes/static_cast_simple.sv         |   64 +
 tests/svtypes/static_cast_verilog.ys        |    4 +
 tests/svtypes/static_cast_zero.ys           |    4 +
 tests/techmap/dff2dffs.ys                   |   24 +-
 tests/techmap/dfflegalize_adff.ys           |  103 ++
 tests/techmap/dfflegalize_adff_init.ys      |  279 ++++
 tests/techmap/dfflegalize_adlatch.ys        |   51 +
 tests/techmap/dfflegalize_adlatch_init.ys   |   99 ++
 tests/techmap/dfflegalize_dff.ys            |  306 ++++
 tests/techmap/dfflegalize_dff_init.ys       |  786 ++++++++++
 tests/techmap/dfflegalize_dffsr.ys          |   88 ++
 tests/techmap/dfflegalize_dffsr_init.ys     |  379 +++++
 tests/techmap/dfflegalize_dlatch.ys         |   42 +
 tests/techmap/dfflegalize_dlatch_init.ys    |   82 +
 tests/techmap/dfflegalize_dlatchsr.ys       |   37 +
 tests/techmap/dfflegalize_dlatchsr_init.ys  |  127 ++
 tests/techmap/dfflegalize_inv.ys            |  178 +++
 tests/techmap/dfflegalize_mince.ys          |   53 +
 tests/techmap/dfflegalize_minsrst.ys        |   43 +
 tests/techmap/dfflegalize_sr.ys             |   74 +
 tests/techmap/dfflegalize_sr_init.ys        |  230 +++
 tests/techmap/zinit.ys                      |  128 +-
 tests/various/const_func.v                  |   75 +
 tests/various/const_func.ys                 |    1 +
 tests/various/signed.ys                     |   28 +
 134 files changed, 10216 insertions(+), 1757 deletions(-)
 create mode 100644 passes/sat/qbfsat.h
 create mode 100644 passes/techmap/dfflegalize.cc
 delete mode 100644 techlibs/ecp5/ecp5_ffinit.cc
 delete mode 100644 techlibs/gowin/determine_init.cc
 delete mode 100644 techlibs/ice40/ice40_ffinit.cc
 create mode 100644 techlibs/intel_alm/common/abc9_map.v
 create mode 100644 techlibs/intel_alm/common/abc9_model.v
 create mode 100644 techlibs/intel_alm/common/abc9_unmap.v
 delete mode 100644 techlibs/intel_alm/common/bram_m10k_map.v
 create mode 100644 techlibs/intel_alm/common/dsp_map.v
 create mode 100644 techlibs/intel_alm/common/dsp_sim.v
 create mode 100644 tests/arch/gowin/init-error.ys
 create mode 100644 tests/arch/intel_alm/blockram.ys
 create mode 100644 tests/arch/intel_alm/mul.ys
 create mode 100644 tests/opt/bug2221.ys
 create mode 100644 tests/opt/opt_expr_combined_assign.ys
 create mode 100644 tests/svtypes/static_cast_negative.ys
 create mode 100644 tests/svtypes/static_cast_nonconst.ys
 create mode 100644 tests/svtypes/static_cast_simple.sv
 create mode 100644 tests/svtypes/static_cast_verilog.ys
 create mode 100644 tests/svtypes/static_cast_zero.ys
 create mode 100644 tests/techmap/dfflegalize_adff.ys
 create mode 100644 tests/techmap/dfflegalize_adff_init.ys
 create mode 100644 tests/techmap/dfflegalize_adlatch.ys
 create mode 100644 tests/techmap/dfflegalize_adlatch_init.ys
 create mode 100644 tests/techmap/dfflegalize_dff.ys
 create mode 100644 tests/techmap/dfflegalize_dff_init.ys
 create mode 100644 tests/techmap/dfflegalize_dffsr.ys
 create mode 100644 tests/techmap/dfflegalize_dffsr_init.ys
 create mode 100644 tests/techmap/dfflegalize_dlatch.ys
 create mode 100644 tests/techmap/dfflegalize_dlatch_init.ys
 create mode 100644 tests/techmap/dfflegalize_dlatchsr.ys
 create mode 100644 tests/techmap/dfflegalize_dlatchsr_init.ys
 create mode 100644 tests/techmap/dfflegalize_inv.ys
 create mode 100644 tests/techmap/dfflegalize_mince.ys
 create mode 100644 tests/techmap/dfflegalize_minsrst.ys
 create mode 100644 tests/techmap/dfflegalize_sr.ys
 create mode 100644 tests/techmap/dfflegalize_sr_init.ys
 create mode 100644 tests/various/const_func.v
 create mode 100644 tests/various/const_func.ys
 create mode 100644 tests/various/signed.ys
```

### stderr:

```Shell
warning: Pulling without specifying how to reconcile divergent branches is
discouraged. You can squelch this message by running one of the following
commands sometime before your next pull:

  git config pull.rebase false  # merge (the default strategy)
  git config pull.rebase true   # rebase
  git config pull.ff only       # fast-forward only

You can replace "git config" with "git config --global" to set a default
preference for all repositories. You can also pass --rebase, --no-rebase,
or --ff-only on the command line to override the configured default per
invocation.

From https://github.com/YosysHQ/yosys
 * branch              master     -> FETCH_HEAD
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- yosys-src

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)