### PR TITLE
Put default export last in package.json

### DIFF
--- a/npmjs/package-in.json
+++ b/npmjs/package-in.json
@@ -21,8 +21,8 @@
         "gen/share/"
     ],
     "exports": {
-        "default": "./gen/bundle.js",
-        "types": "./lib/api.d.ts"
+        "types": "./lib/api.d.ts",
+        "default": "./gen/bundle.js"
     },
     "types": "./lib/api.d.ts",
     "devDependencies": {


### PR DESCRIPTION
Bundlers like Webpack throw an error when the default export is not last, so this PR changes the order.

From the Node.js documentation ([link](https://nodejs.org/api/packages.html#conditional-exports)):
> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.
